### PR TITLE
DG-41: Replace master branch with main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,73 +8,73 @@ WunderFlow is a Git workflow that tries to make it easier to have multiple ongoi
 
 ### Develop
 
-- Branch for showing new features  to customer etc.
-- Deployed to dev server.
+- Branch for showing new features to customer etc.
+- Deployed to `dev` server.
 - Feature / hotfix branches can be merged here anytime for testing purposes.
-- This branch can be reset to master anytime, so no code living only in this branch will end up in production.
+- This branch can be reset to `main` anytime, so no code living only in this branch will end up in `production`.
 - It is also possible to skip this branch if it is possible to use environment per branch.
 
-### Master
+### Main
 
 - Integration / QA for next release.
-- Deployed to stage server.
+- Deployed to `stage` server.
 - Base branch for all new features.
 
 ### Production
 
 - Production.
-- Always equal to the actual code currently running on production servers.
+- Always equal to the actual code currently running on `production` servers.
 
 ## Development workflow
 
 ### New feature
 
-- Create new branch from master
-  - `feature/#[issue/ticket id]-issueTitle` (where # is C for extra/cont dev cases and I for incidents).
-- Merge to develop for testing / acceptance.
-- Merge to master once finished / accepted (or create merge / review request).
+- Create new `feature/[issue/ticket id]-issueTitle` branch from `main`.
+- Merge to `develop` for testing / acceptance.
+- Create a pull request against `main` for peer review.
+- Merge to `main` once finished / accepted.
 
 ### Epic features
 
 Sometimes there might be bigger project that needs to be developed separately and where different features are dependant from each other.
 
-- Create new epic branch `epic/[EpicName]` from master.
-- Create all the feature branches that belong to this project from the epic branch `feature/[EpicName]/[featureInThisEpic]`.
-- Merge feature branches to epic branch, then epic branch to develop for testing.
-- If needed epic branch can be reset to master to clean up experimental features.
-- Only delete feature branches after the epic branch is accepted to master.
-- For release treat epic branch as any other feature branch.
+- Create new `epic` branch `epic/[EpicName]` from `main`.
+- Create all the feature branches that belong to this project from the `epic` branch as follows: `feature/[EpicName]/[featureInThisEpic]`.
+- Merge feature branches to `epic` branch, then `epic` branch to `develop` for testing.
+- If needed `epic` branch can be reset to `main` to clean up experimental features.
+- Only delete feature branches after the `epic` branch is accepted to `main`.
+- For release treat `epic` branch as any other feature branch.
 
 ### Hotfix
 
-- Create new branch from production.
-- Hotfix/#[ticket id]-issueTitle (where # is C for extra/cont dev cases and I for issues, so usually I).
-- Merge to develop for testing.
-- Merge to production for release (or create merge / review request).
-- Rebase master to production.
+- Create new `hotfix/[ticket id]-issueTitle` branch from `production`.
+- Merge to `develop` for testing.
+- Create a pull request against `production` for peer review.
+- Merge to `production` for release.
+- Rebase `main` to `production`.
 
 ### Release
 
-- Merge all accepted / finished feature branches to master (that are not yet merged).
-- Cleanup finished feature branches.
-- Run tests on master.
+- Merge all accepted / finished feature branches to `main` (that are not yet merged).
+- Delete finished feature branches.
+- Run tests on `main`.
 - Tag new release.
-- Merge to production.
+- Merge to `production`.
 
 ## Examples
 
 ### Create a new feature and push it to develop for testing
 
 ```sh
-git checkout master
-git pull origin master
-git checkout -b feature/c1234-adding_this
+git checkout main
+git pull origin main
+git checkout -b feature/ABC-1234-adding_this
 git add
 git commit [... reiterate as many time as needed]
-git push origin feature/c1234-adding_this
+git push origin feature/ABC-1234-adding_this
 git checkout develop
 git pull origin develop
-git merge --no-ff feature/c1234-adding_this
+git merge --no-ff feature/ABC-1234-adding_this
 git push origin develop
 ```
 
@@ -83,38 +83,38 @@ git push origin develop
 ```sh
 git checkout production
 git pull origin production
-git checkout -b hotfix/111-fix
+git checkout -b hotfix/ABC-1234-fix
 git add
 git commit [... reiterate as many time as needed]
-git push origin hotfix/111-fix
+git push origin hotfix/ABC-1234-fix
 git checkout develop
 git pull origin develop
-git merge --no-ff hotfix/111-fix
+git merge --no-ff hotfix/ABC-1234-fix
 git push origin develop
 [test again]
 git checkout production
 git pull origin production
-git merge --no-ff hotfix/111-fix
+git merge --no-ff hotfix/ABC-1234-fix
 git push origin production
-git rebase production master
-git push origin master
+git rebase production main
+git push origin main
 ```
 
-### Publish a feature to master for the pre-release
+### Publish a feature to main for the pre-release
 
 ```sh
-git checkout master
-git pull origin master
-git merge --no-ff feature/c1234-adding_this
-git push origin master
+git checkout main
+git pull origin main
+git merge --no-ff feature/ABC-1234-adding_this
+git push origin main
 ```
 
-### Push master to production
+### Push main to production
 
 ```sh
 git checkout production
 git pull origin production
-git merge --no-ff master
+git merge --no-ff main
 git tag -a mytag -m “mytag”
 git push origin production
 git push --tags

--- a/README.md
+++ b/README.md
@@ -1,63 +1,71 @@
 # Git WunderFlow
 
 ## Description
-WunderFlow is a Git workflow that tries to make it easier to have multiple ongoing development tracks simultaneously while still allowing clean releases and steady hotfixes. It also makes it easy to show any unfinished work to customers. 
 
+WunderFlow is a Git workflow that tries to make it easier to have multiple ongoing development tracks simultaneously while still allowing clean releases and steady hotfixes. It also makes it easy to show any unfinished work to customers.
 
 ## Main branches
 
-
 ### Develop
+
 - Branch for showing new features  to customer etc.
-- Deployed to dev server
-- Feature / hotfix branches can be merged here anytime for testing purposes
-- This branch can be reset to master anytime, so no code living only in this branch will end up in production
-- It is also possible to skip this branch if it is possible to use environment per branch
+- Deployed to dev server.
+- Feature / hotfix branches can be merged here anytime for testing purposes.
+- This branch can be reset to master anytime, so no code living only in this branch will end up in production.
+- It is also possible to skip this branch if it is possible to use environment per branch.
 
 ### Master
-- Integration / QA for next release
-- Deployed to stage server
-- Base branch for all new features
+
+- Integration / QA for next release.
+- Deployed to stage server.
+- Base branch for all new features.
 
 ### Production
-- Production
-- Always equal to the actual code currently running on production servers
+
+- Production.
+- Always equal to the actual code currently running on production servers.
 
 ## Development workflow
 
 ### New feature
-- Create new branch from master 
-  - feature/#[issue/ticket id]-issueTitle (where # is C for extra/cont dev cases and I for incidents)
-- Merge to develop for testing / acceptance
-- Merge to master once finished /accepted (or create merge / review request)
+
+- Create new branch from master
+  - `feature/#[issue/ticket id]-issueTitle` (where # is C for extra/cont dev cases and I for incidents).
+- Merge to develop for testing / acceptance.
+- Merge to master once finished / accepted (or create merge / review request).
 
 ### Epic features
-Sometimes there might be bigger project that needs to be developed separately and where different features are dependant from each other
-- Create new epic branch from master epic/[EpicName]
-- Create all the feature branches that belong to this project from the epic branch feature/[EpicName]/[featureInThisEpic]
-- Merge feature branches to epic branch, then epic branch to develop for testing
-- If needed epic branch can be reset to master to clean up experimental features
-- Only delete feature branches after the epic branch is accepted to master
-- For release treat epic branch as any other feature branch 
+
+Sometimes there might be bigger project that needs to be developed separately and where different features are dependant from each other.
+
+- Create new epic branch `epic/[EpicName]` from master.
+- Create all the feature branches that belong to this project from the epic branch `feature/[EpicName]/[featureInThisEpic]`.
+- Merge feature branches to epic branch, then epic branch to develop for testing.
+- If needed epic branch can be reset to master to clean up experimental features.
+- Only delete feature branches after the epic branch is accepted to master.
+- For release treat epic branch as any other feature branch.
 
 ### Hotfix
-- Create new branch from production
-- Hotfix/#[ticket id]-issueTitle (where # is C for extra/cont dev cases and I for issues, so usually I)
-- Merge to develop for testing
-- Merge to production for release (or create merge / review request)
-- Rebase master to production
+
+- Create new branch from production.
+- Hotfix/#[ticket id]-issueTitle (where # is C for extra/cont dev cases and I for issues, so usually I).
+- Merge to develop for testing.
+- Merge to production for release (or create merge / review request).
+- Rebase master to production.
 
 ### Release
-- Merge all accepted / finished feature branches to master (that are not yet merged)
-- Cleanup finished feature branches
-- Run tests on master
-- Tag new release
-- Merge to production
+
+- Merge all accepted / finished feature branches to master (that are not yet merged).
+- Cleanup finished feature branches.
+- Run tests on master.
+- Tag new release.
+- Merge to production.
 
 ## Examples
 
-Create a new feature and push it to develop for testing
-```
+### Create a new feature and push it to develop for testing
+
+```sh
 git checkout master
 git pull origin master
 git checkout -b feature/c1234-adding_this
@@ -69,8 +77,10 @@ git pull origin develop
 git merge --no-ff feature/c1234-adding_this
 git push origin develop
 ```
-Create a hotfix
-```
+
+### Create a hotfix
+
+```sh
 git checkout production
 git pull origin production
 git checkout -b hotfix/111-fix
@@ -89,16 +99,19 @@ git push origin production
 git rebase production master
 git push origin master
 ```
-Publish a feature to master for the pre-release
-```
+
+### Publish a feature to master for the pre-release
+
+```sh
 git checkout master
 git pull origin master
 git merge --no-ff feature/c1234-adding_this
 git push origin master
 ```
 
-Push master to production
-```
+### Push master to production
+
+```sh
 git checkout production
 git pull origin production
 git merge --no-ff master
@@ -107,7 +120,12 @@ git push origin production
 git push --tags
 ```
 
-### Diagrams
+## Diagrams
 
-![](https://raw.githubusercontent.com/wunderio/wunderflow/master/img/WunderFlow1.png)
-![](https://raw.githubusercontent.com/wunderio/wunderflow/master/img/WunderFlow_epic1.png)
+### WunderFlow
+
+![WunderFlow](https://raw.githubusercontent.com/wunderio/wunderflow/master/img/WunderFlow1.png)
+
+### WunderFlow Epic
+
+![WunderFlow Epic](https://raw.githubusercontent.com/wunderio/wunderflow/master/img/WunderFlow_epic1.png)


### PR DESCRIPTION
Starting October, all new source code repositories created on GitHub will be named `main` instead of `master` as part of the company’s effort to remove unnecessary references to slavery and replace them with more inclusive terms.
Read more: https://github.com/github/renaming#new-repositories-use-main-as-default-branch-name

This PR adds related changes to the WunderFlow workflow and also addresses issue #5.

### Todo

Change diagrams, https://github.com/wunderio/WunderFlow/tree/feature/DG-41-master-to-main#diagrams